### PR TITLE
change example JSON link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you set a domain, it will be automaticaly removed from found objects.
 Metrics collected are defined by associating ObjectType groups with Metric groups.
 They are expressed via the vsphere scheme: *group*.*metric*.*rollup*
 
-An example of configuration file of contoso.com is [there](./vsphere-config.json).
+An example of configuration file of contoso.com is [there](./vsphere-graphite.json).
 
 You need to place it at /etc/*binaryname*.json (/etc/vsphere-graphite.json per default)
 


### PR DESCRIPTION
The link in the README to the example JSON was pointing to a non-existant file.