### PR TITLE
Adds ElasticSearch backend to vsphere-graphite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ deps:
 	go get github.com/pquerna/ffjson/fflib/v1
 	go get code.cloudfoundry.org/bytefmt
 	go get github.com/pquerna/ffjson
+	go get github.com/olivere/elastic
 	go generate ./...
 
 build-windows-amd64:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Backend paramters can also be set via environement paramterers (see docker)
 
 ### Backend parameters
 
-- Type (BACKEND_TYPE): Type of backend to use. Currently "graphite", "influxdb" or "thinfluxdb" (influx client in the project)
+- Type (BACKEND_TYPE): Type of backend to use. Currently "graphite", "influxdb", "thinfluxdb" or elasticsearch (influx client in the project)
 
 - Hostname (BACKEND_HOSTNAME): hostname were the backend is running (graphite, influxdb, thinfluxdb)
 
@@ -63,7 +63,7 @@ Backend paramters can also be set via environement paramterers (see docker)
 
 - Password (BACKEND_PASSWORD): password to connect to the backend (influxdb and optionally for thinfluxdb)
 
-- Database (BACKEND_DATABASE): database to use in the backend (influxdb, thinfluxdb)
+- Database (BACKEND_DATABASE): database to use in the backend (influxdb, thinfluxdb, elasticsearch)
 
 - NoArray (BACKEND_NOARRAY): don't use csv 'array' as tags, only the first element is used (influxdb, thinfluxdb)
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -16,6 +15,7 @@ import (
 	influxclient "github.com/influxdata/influxdb/client/v2"
 	"github.com/marpaia/graphite-golang"
 	"github.com/olivere/elastic"
+	json "github.com/pquerna/ffjson/ffjson"
 )
 
 // Point : Information collected for a point
@@ -393,7 +393,6 @@ func (backend *BackendConfig) SendMetrics(metrics []*Point) {
 			if err != nil {
 				errlog.Println("Error creating Elastic index:" + elasticindex)
 				panic(err)
-				break
 			}
 			if !createIndex.Acknowledged {
 				// Not acknowledged

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -216,8 +216,8 @@ func (backend *BackendConfig) Init(standardLogs *log.Logger, errorLogs *log.Logg
 		backend.elastic = elasticclt
 		return nil
 	default:
-		errlog.Println("Init: Backend " + backendType + " unknown.")
-		return errors.New("Init: Backend " + backendType + " unknown.")
+		errlog.Println("Backend " + backendType + " unknown.")
+		return errors.New("Backend " + backendType + " unknown.")
 	}
 }
 
@@ -241,7 +241,7 @@ func (backend *BackendConfig) Disconnect() {
 		// Disconnect from Elastic
 		errlog.Println("Disconnecting from elastic")
 	default:
-		errlog.Println("Disconnect: Backend " + backendType + " unknown.")
+		errlog.Println("Backend " + backendType + " unknown.")
 	}
 }
 
@@ -409,7 +409,7 @@ func (backend *BackendConfig) SendMetrics(metrics []*Point) {
 				continue
 			}
 			//key := "vsphere." + vcName + "." + entityName + "." + name + "." + metricName
-			key := "vsphere." + point.VCenter + "." + point.ObjectType + "." + point.ObjectName + "." + point.Group + "." + point.Counter + "." + point.Rollup
+			key := "vsphere." + point.VCenter + "." + point.Cluster + "." + point.ObjectType + "." + point.ObjectName + "." + point.Group + "." + point.Counter + "." + point.Rollup
 			if len(point.Instance) > 0 {
 				key += "." + strings.ToLower(strings.Replace(point.Instance, ".", "_", -1))
 			}
@@ -427,10 +427,10 @@ func (backend *BackendConfig) SendMetrics(metrics []*Point) {
 			_, err := backend.elastic.Index().
 				Index("vsphere-graphite").
 				Type("vSphereMetricType").
-				Id("1").
+				//Id("1").
 				BodyJson(row).
-				//BodyString(row).
-				Do(ctx)
+				//Refresh("wait_for").
+				Do(context.Background())
 			if err != nil {
 				// Handle error
 				panic(err)
@@ -445,6 +445,6 @@ func (backend *BackendConfig) SendMetrics(metrics []*Point) {
 		}
 
 	default:
-		errlog.Println("SendMetrics: Backend " + backendType + " unknown.")
+		errlog.Println("Backend " + backendType + " unknown.")
 	}
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -203,9 +203,9 @@ func (backend *BackendConfig) Init(standardLogs *log.Logger, errorLogs *log.Logg
 		return nil
 	case Elastic:
 		//Initialize Elastic client
-		stdlog.Println("Initializing " + backendType + " backend")
+		stdlog.Println("Initializing " + backendType + " backend " + backend.Hostname + ":" + strconv.Itoa(backend.Port))
 		elasticclt, err := elastic.NewClient(
-			elastic.SetURL("https://monrkn-vccn007.wsgc.com:9200"),
+			elastic.SetURL("https://"+backend.Hostname+":"+strconv.Itoa(backend.Port)),
 			elastic.SetMaxRetries(10),
 			elastic.SetScheme("https"),
 			elastic.SetBasicAuth(backend.Username, backend.Password))

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -422,10 +422,13 @@ func (backend *BackendConfig) SendMetrics(metrics []*Point) {
 				"vsphere." + point.ObjectType + "." + point.Group + "." + point.Counter + "." + point.Rollup: strconv.FormatInt(point.Value, 10),
 			}
 
-			row, _ := ffjson.Marshal(m)
+			row, err := ffjson.Marshal(m)
+			if err != nil {
+				errlog.Println("JSON Marshalling failed with error: ", err)
+			}
 			//stdlog.Println(string(row))
 
-			_, err := backend.elastic.Index().
+			_, err = backend.elastic.Index().
 				Index(elasticindex).
 				Type("doc").
 				//BodyJson(row).

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -15,7 +15,7 @@ import (
 	influxclient "github.com/influxdata/influxdb/client/v2"
 	"github.com/marpaia/graphite-golang"
 	"github.com/olivere/elastic"
-	json "github.com/pquerna/ffjson/ffjson"
+	"github.com/pquerna/ffjson/ffjson"
 )
 
 // Point : Information collected for a point
@@ -422,7 +422,7 @@ func (backend *BackendConfig) SendMetrics(metrics []*Point) {
 				"vsphere." + point.ObjectType + "." + point.Group + "." + point.Counter + "." + point.Rollup: strconv.FormatInt(point.Value, 10),
 			}
 
-			row, _ := json.Marshal(m)
+			row, _ := ffjson.Marshal(m)
 			//stdlog.Println(string(row))
 
 			_, err := backend.elastic.Index().

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -247,6 +247,7 @@ func (backend *BackendConfig) Disconnect() {
 
 // SendMetrics : send metrics to backend
 func (backend *BackendConfig) SendMetrics(metrics []*Point) {
+	stdlog.Println("SendMetrics to backend")
 	switch backendType := strings.ToLower(backend.Type); backendType {
 	case Graphite:
 		var graphiteMetrics []graphite.Metric
@@ -388,7 +389,7 @@ func (backend *BackendConfig) SendMetrics(metrics []*Point) {
 			// Handle error
 			panic(err)
 		} else {
-			stdlog.Println("Elastic index: 'vsphere-graphite' already exists")
+			stdlog.Println("Elastic index: 'vsphere-graphite' already exists. Ateempting to Sink Metris")
 		}
 		if !exists {
 			// Create a new index.
@@ -415,7 +416,6 @@ func (backend *BackendConfig) SendMetrics(metrics []*Point) {
 			//row := append(row, (Name: key, Value: strconv.FormatInt(point.Value, 10), Timestamp: point.Timestamp))
 			//row := append(row, `{"Name" : key, "Value" : strconv.FormatInt(point.Value, 10), Timestamp: point.Timestamp}`)
 
-			stdlog.Println(key)
 			row := vSphereMetricType{
 				//Timestamp: point.Timestamp,
 				Timestamp: time.Now(),
@@ -423,6 +423,7 @@ func (backend *BackendConfig) SendMetrics(metrics []*Point) {
 				Value:     strconv.FormatInt(point.Value, 10),
 			}
 
+			stdlog.Println(row)
 			_, err := backend.elastic.Index().
 				Index("vsphere-graphite").
 				Type("vSphereMetricType").
@@ -430,7 +431,6 @@ func (backend *BackendConfig) SendMetrics(metrics []*Point) {
 				BodyJson(row).
 				//BodyString(row).
 				Do(ctx)
-			fmt.Printf(key, strconv.FormatInt(point.Value, 10))
 			if err != nil {
 				// Handle error
 				panic(err)

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -241,7 +241,6 @@ func (backend *BackendConfig) Disconnect() {
 
 // SendMetrics : send metrics to backend
 func (backend *BackendConfig) SendMetrics(metrics []*Point) {
-	stdlog.Println("SendMetrics to backend")
 	switch backendType := strings.ToLower(backend.Type); backendType {
 	case Graphite:
 		var graphiteMetrics []graphite.Metric
@@ -425,7 +424,7 @@ func (backend *BackendConfig) SendMetrics(metrics []*Point) {
 			}
 
 			row, _ := json.Marshal(m)
-			stdlog.Println(string(row))
+			//stdlog.Println(string(row))
 
 			_, err := backend.elastic.Index().
 				Index(elasticindex).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,8 @@ MAINTAINER cblomart@gmail.com
 
 COPY ./vsphere-graphite /vsphere-graphite
 COPY ./vsphere-graphite.json /etc/vsphere-graphite.json
+# Backends my require TLS:
+# COPY ./ca-certificates.crt /etc/ssl/certs/
 
 VOLUME [ "/etc" ]
 

--- a/vsphere-graphite-elastic-index-mappings.json
+++ b/vsphere-graphite-elastic-index-mappings.json
@@ -1,0 +1,290 @@
+PUT _template/vsphere_graphite 
+{
+    "vsphere_graphite": {
+        "order": 0,
+        "index_patterns": [
+            "vsphere-graphite-*"
+        ],
+        "settings": {
+            "index": {
+                "number_of_shards": "1",
+                "number_of_replicas": "1"
+            }
+        },
+        "mappings": {
+            "doc": {
+                "properties": {
+                    "@timestamp": {
+                        "type": "date"
+                    },
+                    "cluster": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "vcenter": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "vsphere": {
+                        "properties": {
+                            "hostsystem": {
+                                "properties": {
+                                    "cpu": {
+                                        "properties": {
+                                            "totalcapacity": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "usage": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "usagemhz": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "disk": {
+                                        "properties": {
+                                            "maxtotallatency": {
+                                                "properties": {
+                                                    "latest": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "numberreadaveraged": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "numberwriteaveraged": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "mem": {
+                                        "properties": {
+                                            "active": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "long"
+                                                    }
+                                                }
+                                            },
+                                            "consumed": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "long"
+                                                    }
+                                                }
+                                            },
+                                            "totalcapacity": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "long"
+                                                    }
+                                                }
+                                            },
+                                            "usage": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "long"
+                                                    }
+                                                }
+                                            },
+                                            "vmmemctl": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "long"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "name": {
+                                        "type": "text",
+                                        "fields": {
+                                            "keyword": {
+                                                "type": "keyword",
+                                                "ignore_above": 256
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "virtualmachine": {
+                                "properties": {
+                                    "cpu": {
+                                        "properties": {
+                                            "ready": {
+                                                "properties": {
+                                                    "summation": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "usage": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "usagemhz": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "guestdisk": {
+                                        "properties": {
+                                            "capacity": {
+                                                "properties": {
+                                                    "latest": {
+                                                        "type": "long"
+                                                    }
+                                                }
+                                            },
+                                            "freespace": {
+                                                "properties": {
+                                                    "latest": {
+                                                        "type": "long"
+                                                    }
+                                                }
+                                            },
+                                            "usage": {
+                                                "properties": {
+                                                    "latest": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "mem": {
+                                        "properties": {
+                                            "active": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "long"
+                                                    }
+                                                }
+                                            },
+                                            "consumed": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "long"
+                                                    }
+                                                }
+                                            },
+                                            "usage": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "long"
+                                                    }
+                                                }
+                                            },
+                                            "vmmemctl": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "long"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "name": {
+                                        "type": "text",
+                                        "fields": {
+                                            "keyword": {
+                                                "type": "keyword",
+                                                "ignore_above": 256
+                                            }
+                                        }
+                                    },
+                                    "virtualdisk": {
+                                        "properties": {
+                                            "numberreadaveraged": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "numberwriteaveraged": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "read": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "totalreadlatency": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "totalwritelatency": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "write": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "aliases": {}
+    }
+}

--- a/vsphere-graphite-elastic-index-mappings.json
+++ b/vsphere-graphite-elastic-index-mappings.json
@@ -1,10 +1,10 @@
-PUT _template/vsphere_graphite 
+POST _template/vsphere_graphite
 {
-    "vsphere_graphite": {
         "order": 0,
         "index_patterns": [
             "vsphere-graphite-*"
         ],
+        "version": 2,
         "settings": {
             "index": {
                 "number_of_shards": "1",
@@ -86,6 +86,34 @@ PUT _template/vsphere_graphite
                                                         "type": "integer"
                                                     }
                                                 }
+                                            },
+                                            "read": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "write": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "totalreadlatency": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "totalwritelatency": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
                                             }
                                         }
                                     },
@@ -134,6 +162,31 @@ PUT _template/vsphere_graphite
                                             "keyword": {
                                                 "type": "keyword",
                                                 "ignore_above": 256
+                                            }
+                                        }
+                                    },
+                                    "net": {
+                                        "properties": {
+                                            "received": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "transmitted": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "usage": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
                                             }
                                         }
                                     }
@@ -232,6 +285,31 @@ PUT _template/vsphere_graphite
                                             }
                                         }
                                     },
+                                    "net": {
+                                        "properties": {
+                                            "received": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "transmitted": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            },
+                                            "usage": {
+                                                "properties": {
+                                                    "average": {
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
                                     "virtualdisk": {
                                         "properties": {
                                             "numberreadaveraged": {
@@ -285,6 +363,5 @@ PUT _template/vsphere_graphite
                 }
             }
         },
-        "aliases": {}
-    }
+        "aliases": {}   
 }

--- a/vsphere/vsphere.go
+++ b/vsphere/vsphere.go
@@ -212,22 +212,18 @@ func (vcenter *VCenter) Query(interval int, domain string, channel *chan backend
 		errlog.Println("Error: ", err)
 		return
 	}
-	i := 0
+
 	for _, child := range dcs {
-		stdlog.Println(child.Reference())
-		// GM* custom loop to choose only 1 datacenter
-		if i == 1 {
-			datacenters = append(datacenters, child.Reference())
-		}
-		i++
+		datacenters = append(datacenters, child.Reference())
 	}
+
 	// for _, child := range rootFolder.ChildEntity {
 	// 	if child.Type == "Datacenter" {
 	// 		datacenters = append(datacenters, child)
 	// 	}
 	// }
 
-	// Get intresting object types from specified queries
+	// Get interesting object types from specified queries
 	objectTypes := []string{"ClusterComputeResource", "Datastore", "HostSystem", "DistributedVirtualPortgroup", "Network", "ResourcePool", "Folder"}
 	for _, group := range vcenter.MetricGroups {
 		found := false

--- a/vsphere/vsphere.go
+++ b/vsphere/vsphere.go
@@ -212,11 +212,9 @@ func (vcenter *VCenter) Query(interval int, domain string, channel *chan backend
 		errlog.Println("Error: ", err)
 		return
 	}
-
 	for _, child := range dcs {
 		datacenters = append(datacenters, child.Reference())
 	}
-
 	// for _, child := range rootFolder.ChildEntity {
 	// 	if child.Type == "Datacenter" {
 	// 		datacenters = append(datacenters, child)

--- a/vsphere/vsphere.go
+++ b/vsphere/vsphere.go
@@ -212,8 +212,14 @@ func (vcenter *VCenter) Query(interval int, domain string, channel *chan backend
 		errlog.Println("Error: ", err)
 		return
 	}
+	i := 0
 	for _, child := range dcs {
-		datacenters = append(datacenters, child.Reference())
+		stdlog.Println(child.Reference())
+		// GM* custom loop to choose only 1 datacenter
+		if i == 1 {
+			datacenters = append(datacenters, child.Reference())
+		}
+		i++
 	}
 	// for _, child := range rootFolder.ChildEntity {
 	// 	if child.Type == "Datacenter" {


### PR DESCRIPTION
Adds ElasticSearch backend to vsphere-graphite

Not yet optimal but does the job. Currently each metric within a sample period is submitted/indexed individually. In future will look to use the elastic bulkindexrequest. This will upload/index all metrics per sample period in a single call.

Uses the backend.Database field in the JSON for the ElasicSearch Index name.

Elastic Search field mapping provided for easy import into Elastic: vsphere-graphite-elastic-index-mappings.json

Relates to #28