### PR TITLE
correct guestdisk capacity usage value calculation from 10000% to 100%

### DIFF
--- a/vsphere/vsphere.go
+++ b/vsphere/vsphere.go
@@ -692,7 +692,7 @@ func (vcenter *VCenter) Query(interval int, domain string, channel *chan backend
 					Counter:      "usage",
 					Instance:     diskPath,
 					Rollup:       "latest",
-					Value:        int64(10000 * (1 - (float64(diskInfo.FreeSpace) / float64(diskInfo.Capacity)))),
+					Value:        int64(100 * (1 - (float64(diskInfo.FreeSpace) / float64(diskInfo.Capacity)))),
 					Datastore:    datastore,
 					ESXi:         vmhost,
 					Cluster:      cluster,


### PR DESCRIPTION
The guestdisk.capacity.usage metric is a percentage value that is being calculated to a value of 10000% rather than 100%

Change from:
percentage = 10000 * (1 - (x / y))
to:
percentage = 100 * (1 - (x / y))