### PR TITLE
Fix typo and non-existing performance metrics

### DIFF
--- a/vsphere-graphite-example.json
+++ b/vsphere-graphite-example.json
@@ -37,12 +37,10 @@
       "ObjectType": [ "VirtualMachine" ], 
       "Definition": [
         { "Metric": "virtualDisk.totalWriteLatency.average", "Instances": "*" },
-        { "Metric": "virtualDisk.totalWriteLatency.maximum", "Instances": "*" },
         { "Metric": "virtualDisk.totalReadLatency.average", "Instances": "*" },
-        { "Metric": "virtualDisk.totalReadLatency.maximum", "Instances": "*" },
         { "Metric": "virtualDisk.numberReadAveraged.average", "Instances": "*" },
         { "Metric": "virtualDisk.numberWriteAveraged.average", "Instances": "*" },
-        { "Metric": "cpu.read.summation", "Instance": ""}
+        { "Metric": "cpu.ready.summation", "Instance": ""}
       ]
     },
     { 


### PR DESCRIPTION
virtualDisk.totalRead/WriteLatency.maximum doesn't exist it seems!
See: https://www.vmware.com/support/developer/converter-sdk/conv61_apireference/virtual_disk_counters.html