### PR TITLE
Added the option for a Prometheus backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ deps:
 	go get code.cloudfoundry.org/bytefmt
 	go get github.com/pquerna/ffjson
 	go get github.com/olivere/elastic
+	go get github.com/prometheus/client_golang/prometheus
 	go generate ./...
 
 build-windows-amd64:

--- a/backend/config.go
+++ b/backend/config.go
@@ -22,4 +22,7 @@ type Config struct {
 	influx       *influxclient.Client
 	thininfluxdb *thininfluxclient.ThinInfluxClient
 	elastic      *elastic.Client
+	channel      *chan bool
+	doneChannel  *chan bool
+	promMetrics  *chan Point
 }

--- a/vsphere/vsphere.go
+++ b/vsphere/vsphere.go
@@ -140,7 +140,7 @@ func (vcenter *VCenter) Init(metrics []*Metric, standardLogs *log.Logger, errorL
 }
 
 // Query : Query a vcenter
-func (vcenter *VCenter) Query(interval int, domain string, properties []string, channel *chan backend.Point) {
+func (vcenter *VCenter) Query(interval int, domain string, properties []string, channel *chan backend.Point, done *chan bool) {
 	stdlog.Println("Setting up query inventory of vcenter: ", vcenter.Hostname)
 
 	// Create the contect
@@ -675,4 +675,5 @@ func (vcenter *VCenter) Query(interval int, domain string, properties []string, 
 		}
 	}
 	stdlog.Println("Got " + strconv.Itoa(returncount) + " results from " + vcenter.Hostname + " with " + strconv.Itoa(valuescount) + " values")
+	*done <- true
 }


### PR DESCRIPTION
Prometheus is pull, so this is handled a bit different.
We first start a promhttp which is a daemon listening to requests on /metrics via HTTP.
If a GET is received there, the metrics are queried on the vCenter and returned via HTTP.

This is the initial commit. I guess some things will need to get changed before it can be merged.
Feel free to comment!