### PR TITLE
Add option for fluentd backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ deps:
 	go get github.com/pquerna/ffjson
 	go get github.com/olivere/elastic
 	go get github.com/prometheus/client_golang/prometheus
+	github.com/fluent/fluent-logger-golang/fluent
 	go generate ./...
 
 build-windows-amd64:
@@ -42,7 +43,7 @@ build-darwin-amd64:
 
 dist-darwin-amd64:
 	@$(MAKE) dist GOOS=darwin GOARCH=amd64
-    
+
 build-linux-arm:
 	@$(MAKE) build GOOS=linux GOARCH=arm GOARM=5
 
@@ -66,7 +67,7 @@ docker-push:
 		docker push cblomart/$(PREFIX)vsphere-graphite:$(TAG);\
 		docker push cblomart/$(PREFIX)vsphere-graphite:latest;\
 	fi
-    
+
 
 docker-linux-amd64:
 	@$(MAKE) docker-build GOOS=linux GOARCH=amd64
@@ -79,7 +80,7 @@ docker-darwin-amd64: ;
 docker-windows-amd64: ;
 
 push-linux-amd64:
-	@$(MAKE) docker-push 
+	@$(MAKE) docker-push
 
 push-linux-arm:
 	@$(MAKE) docker-push PREFIX=rpi-
@@ -123,9 +124,9 @@ dev:
 	git pull
 	@$(MAKE) clean
 	@$(MAKE) build-linux-amd64
-	
+
 all:
-	@$(MAKE) dist-windows-amd64 
+	@$(MAKE) dist-windows-amd64
 	@$(MAKE) dist-linux-amd64
 	@$(MAKE) dist-darwin-amd64
 	@$(MAKE) dist-linux-arm

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ deps:
 	go get github.com/pquerna/ffjson
 	go get github.com/olivere/elastic
 	go get github.com/prometheus/client_golang/prometheus
-	github.com/fluent/fluent-logger-golang/fluent
+	go get github.com/fluent/fluent-logger-golang/fluent
 	go generate ./...
 
 build-windows-amd64:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can select the extra data collected by using the "Properties" property:
 
 ### Backend parameters
 
-* Type (BACKEND_TYPE): Type of backend to use. Currently "graphite", "influxdb", "thinfluxdb" (embeded influx client) or "elasticsearch"
+* Type (BACKEND_TYPE): Type of backend to use. Currently "graphite", "influxdb", "thinfluxdb" (embeded influx client), "elastic", and "fluentd"
 * Hostname (BACKEND_HOSTNAME): hostname were the backend is running
 * Port (BACKEND_PORT): port to connect to for the backend
 * Encrypted (BACKEND_ENCRYPTED): enable or disable TLS to backend (true, false)
@@ -61,6 +61,7 @@ You can select the extra data collected by using the "Properties" property:
 * Password (BACKEND_PASSWORD): password to connect to the backend (influxdb and optionally for thinfluxdb & elasticsearch)
 * Database (BACKEND_DATABASE): database to use in the backend (influxdb, thinfluxdb, elasticsearch)
 * NoArray (BACKEND_NOARRAY): don't use csv 'array' as tags, only the first element is used (influxdb, thinfluxdb)
+* Tag (BACKEND_TAG): tag to use in the backend (fluent)
 
 ## Execute vsphere-graphite as a container
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -158,7 +158,7 @@ func (backend *Config) Init() error {
 		//Initialize Influx DB
 		log.Println("Initializing " + backendType + " backend")
 
-		if backend.Tag == "" {
+		if len(backend.Tag) == 0 {
 			log.Println("backend.Tag not specified in vsphere-graphite.json")
 		}
 		fluentclt, err := fluent.New(fluent.Config{FluentPort: backend.Port, FluentHost: backend.Hostname, MarshalAsJSON: true})

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 
 	"github.com/cblomart/vsphere-graphite/backend/thininfluxclient"
+	"github.com/fluent/fluent-logger-golang/fluent"
 	influxclient "github.com/influxdata/influxdb/client/v2"
 	"github.com/marpaia/graphite-golang"
 	"github.com/olivere/elastic"
@@ -44,6 +45,8 @@ const (
 	Elastic = "elastic"
 	// Prometheus name of the prometheus backend
 	Prometheus = "prometheus"
+	// Fluentd name of the fluentd backend
+	Fluentd = "fluentd"
 )
 
 var stdlog, errlog *log.Logger
@@ -151,6 +154,21 @@ func (backend *Config) Init() error {
 			return nil
 		}()
 		return nil
+	case Fluentd:
+		//Initialize Influx DB
+		log.Println("Initializing " + backendType + " backend")
+
+		if backend.Tag == nil {
+			log.Println("backend.Tag not specified in vsphere-graphite.json")
+		}
+		fluentclt, err := fluent.New(fluent.Config{FluentPort: backend.Port, FluentHost: backend.Hostname, MarshalAsJSON: true})
+		if err != nil {
+			log.Println("Error connecting to Fluentd")
+			return err
+		}
+		backend.fluent = fluentclt
+		return nil
+
 	default:
 		log.Println("Backend " + backendType + " unknown.")
 		return errors.New("Backend " + backendType + " unknown.")
@@ -179,6 +197,9 @@ func (backend *Config) Disconnect() {
 	case Prometheus:
 		// Stop Exporting Prometheus Metrics
 		log.Println("Stopping exporter")
+	case Fluentd:
+		// Disconnect from Elastic
+		log.Println("Disconnecting from fluent")
 	default:
 		log.Println("Backend " + backendType + " unknown.")
 	}
@@ -296,6 +317,15 @@ func (backend *Config) SendMetrics(metrics []*Point) {
 		}
 	case Prometheus:
 		// Prometheus doesn't need to send metrics
+	case Fluentd:
+		for _, point := range metrics {
+			if point != nil {
+				err := backend.fluent.Post(backend.Tag, *point)
+				if err != nil {
+					log.Println(err)
+				}
+			}
+		}
 	default:
 		log.Println("Backend " + backendType + " unknown.")
 	}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -158,7 +158,7 @@ func (backend *Config) Init() error {
 		//Initialize Influx DB
 		log.Println("Initializing " + backendType + " backend")
 
-		if backend.Tag == nil {
+		if backend.Tag == "" {
 			log.Println("backend.Tag not specified in vsphere-graphite.json")
 		}
 		fluentclt, err := fluent.New(fluent.Config{FluentPort: backend.Port, FluentHost: backend.Hostname, MarshalAsJSON: true})

--- a/backend/config.go
+++ b/backend/config.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"github.com/cblomart/vsphere-graphite/backend/thininfluxclient"
+	"github.com/fluent/fluent-logger-golang/fluent"
 	influxclient "github.com/influxdata/influxdb/client/v2"
 	graphite "github.com/marpaia/graphite-golang"
 	"github.com/olivere/elastic"
@@ -15,6 +16,7 @@ type Config struct {
 	Username     string
 	Password     string
 	Type         string
+	Tag          string
 	Port         int
 	NoArray      bool
 	Encrypted    bool
@@ -22,6 +24,7 @@ type Config struct {
 	influx       *influxclient.Client
 	thininfluxdb *thininfluxclient.ThinInfluxClient
 	elastic      *elastic.Client
+	fluent       *fluent.Fluent
 	channel      *chan bool
 	doneChannel  *chan bool
 	promMetrics  *chan Point


### PR DESCRIPTION
Add a fluentd backend.  It's fairly straightforward - the fluentd client
doesn't seem to have a concept of bulk operations, so we just send a new
message for point.

Comments welcome - I don't really know Go at all.