### PR TITLE
fix windows compatbility. config file in current directory

### DIFF
--- a/vsphere-graphite.go
+++ b/vsphere-graphite.go
@@ -78,9 +78,9 @@ func (service *Service) Manage() (string, error) {
 	configname := strings.TrimSuffix(basename, filepath.Ext(basename))
 	location := "/etc/" + configname + ".json"
 	if _, err := os.Stat(location); err!=nil {
-		location = "./" + configname + ".json"
+		location = configname + ".json"
 		if _, err := os.Stat(location); err!=nil {
-			return "Could not find config location in './' or '/etc'", err
+			return "Could not find config location in '.' or '/etc'", err
 		}
 	}
 	


### PR DESCRIPTION
Fix issue #85

The path separator is OS specific (os.PathSeparator).
But there is no need to prefix current directory with "./" anyway.



