### PR TITLE
Enabled at-least-once message transferring

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -170,9 +170,9 @@ func (backend *Config) Init() (*chan Channels, error) {
 		}()
 		return queries, nil
 	case Fluentd:
-		//Initialize Influx DB
+		//Initialize Fluentd
 		log.Printf("backend %s: initializing\n", backendType)
-		fluentclt, err := fluent.New(fluent.Config{FluentPort: backend.Port, FluentHost: backend.Hostname, MarshalAsJSON: true})
+		fluentclt, err := fluent.New(fluent.Config{FluentPort: backend.Port, FluentHost: backend.Hostname, MarshalAsJSON: true, RequestAck: true})
 		if err != nil {
 			log.Printf("backend %s: error connecting - %s\n", backendType, err)
 			return queries, err


### PR DESCRIPTION
In current configuration, fluentd client drops some messages when destination fluentd server is down.
So I added RequestAck option to avoid this.

ref: https://github.com/fluent/fluent-logger-golang/blob/master/CHANGELOG.md#140