### PR TITLE
add kafka backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Compatible backends:
 * [fluentd](https://www.fluentd.org/)
 * [elasticsearch](https://www.elastic.co/)
 * [graphite](https://graphiteapp.org/)
+* [kafka](https://kafka.apache.org)
 
 ## Example dashboard
 
@@ -85,7 +86,7 @@ This allows to use a generic config in a container image and set the backend by 
 
   Type of backend to use.
 
-  Currently "graphite", "influxdb", "thinfluxdb" (embeded influx client), "elastic", "prometheus", "thinprometheus" (embedded prometheus) and "fluentd"
+  Currently "graphite", "influxdb", "thinfluxdb" (embeded influx client), "elastic", "prometheus", "thinprometheus" (embedded prometheus) "fluentd" and "kafka"
 
 * Hostname (CONFIG_HOSTNAME):
 
@@ -127,7 +128,7 @@ This allows to use a generic config in a container image and set the backend by 
 
   Database to use in the backend.
 
-  Only supported by "influx", "thininflux" and "elastic".
+  Only supported by "influx", "thininflux", "elastic" and "kafka" (kafka topic name)
 
 * NoArray (CONFIG_NOARRAY):
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -2,16 +2,15 @@ package backend
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/cblomart/vsphere-graphite/utils"
 	"log"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/cblomart/vsphere-graphite/utils"
-
-	"net/http"
 
 	"github.com/cblomart/vsphere-graphite/backend/thininfluxclient"
 	"github.com/fluent/fluent-logger-golang/fluent"
@@ -20,6 +19,8 @@ import (
 	graphite "github.com/marpaia/graphite-golang"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	kafka "github.com/segmentio/kafka-go"
+	"github.com/segmentio/kafka-go/gzip"
 	elastic "gopkg.in/olivere/elastic.v5"
 )
 
@@ -55,6 +56,8 @@ const (
 	Fluentd = "fluentd"
 	// ThinPrometheus name of the thin prometheus backend
 	ThinPrometheus = "thinprometheus"
+	// Kafka name of the kafka backend
+	Kafka = "kafka"
 )
 
 var (
@@ -193,6 +196,21 @@ func (backend *Config) Init() (*chan Channels, error) {
 			}
 		}()
 		return queries, nil
+	case Kafka:
+		//Initialize Kafka
+		log.Printf("backend %s: initializing\n", backendType)
+		kafkaclt := kafka.NewWriter(kafka.WriterConfig{
+			Brokers:          []string{backend.Hostname + ":" + strconv.Itoa(backend.Port)},
+			Topic:            backend.Database,
+			Balancer:         &kafka.LeastBytes{},
+			CompressionCodec: gzip.NewCompressionCodec(),
+			RequiredAcks:     1, //default -1
+			//BatchTimeout: 1 * time.Millisecond, //default 1 * time.Second,
+		})
+		log.Printf("backend %s: broker:%s:%d topic:%s\n", backendType, backend.Hostname, backend.Port, backend.Database)
+
+		backend.kafka = kafkaclt
+		return queries, nil
 	default:
 		log.Printf("backend %s: unknown backend\n", backendType)
 		return queries, errors.New("backend " + backendType + " unknown.")
@@ -250,6 +268,10 @@ func (backend *Config) Disconnect() {
 	case ThinPrometheus:
 		// Stop exporting Prometheus metrics
 		log.Println("Disconnect ThinPrometheus exporter")
+	case Kafka:
+		// Disconnect from Kafka
+		log.Println("Disconnect from Kafka")
+		backend.kafka.Close()
 	default:
 		log.Println("Backend " + backendType + " unknown.")
 	}
@@ -382,6 +404,19 @@ func (backend *Config) SendMetrics(metrics []*Point, cleanup bool) {
 		}
 	case ThinPrometheus:
 		// Thin Prometheus doesn't need to send metrics
+	case Kafka:
+		// Format metrics into json and write to kafka
+		msg, _ := json.Marshal(metrics)
+		err := backend.kafka.WriteMessages(context.Background(),
+			kafka.Message{Value: []byte(msg)},
+		)
+		if err != nil {
+			log.Printf("backend %s: failed to post point - %s\n", backendType, err)
+		}
+
+		//Log Kafka Writer Stats
+		log.Println("kafka stats:", backend.kafka.Stats())
+
 	default:
 		log.Printf("backend %s: unknown", backendType)
 	}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -271,7 +271,9 @@ func (backend *Config) Disconnect() {
 	case Kafka:
 		// Disconnect from Kafka
 		log.Println("Disconnect from Kafka")
-		backend.kafka.Close()
+		if err := backend.kafka.Close(); err != nil {
+			log.Fatal("failed to close kafka writer:", err)
+		}
 	default:
 		log.Println("Backend " + backendType + " unknown.")
 	}

--- a/backend/config.go
+++ b/backend/config.go
@@ -6,6 +6,7 @@ import (
 
 	influxclient "github.com/influxdata/influxdb1-client/v2"
 	graphite "github.com/marpaia/graphite-golang"
+	kafka "github.com/segmentio/kafka-go"
 	elastic "gopkg.in/olivere/elastic.v5"
 )
 
@@ -26,4 +27,5 @@ type Config struct {
 	thininfluxdb *thininfluxclient.ThinInfluxClient
 	elastic      *elastic.Client
 	fluent       *fluent.Fluent
+	kafka        *kafka.Writer
 }


### PR DESCRIPTION
Adds a Kafka backend for more durability and adaptability. Metrics can be consumed into alternate backends that are not in the current supported list.